### PR TITLE
Support SignalFlow WebSocket message compression

### DIFF
--- a/lib/client/conf.js
+++ b/lib/client/conf.js
@@ -8,6 +8,9 @@ exports.DEFAULT_SIGNALFLOW_WEBSOCKET_ENDPOINT = 'wss://stream.signalfx.com';
 exports.DEFAULT_BATCH_SIZE = 300;// Will wait for this many requests before posting
 exports.DEFAULT_TIMEOUT = 1000; // Default timeout is 1s
 
+// Whether to request SignalFlow WebSocket message compression.
+exports.COMPRESS_SIGNALFLOW_WEBSOCKET_MESSAGES = true;
+
 // Global Parameters
 exports.PROTOBUF_HEADER_CONTENT_TYPE = 'application/x-protobuf';
 exports.JSON_HEADER_CONTENT_TYPE = 'application/json';

--- a/lib/client/signalflow/request_manager.js
+++ b/lib/client/signalflow/request_manager.js
@@ -239,6 +239,7 @@ function RequestManager(endPoint) {
         requestType: requestType,
         isRetryPatchMode: isRetryPatchMode});
     } else {
+      params.compress = conf.COMPRESS_SIGNALFLOW_WEBSOCKET_MESSAGES;
       addComputation(params, requestId, transports.WEBSOCKET, cb, requestType, isRetryPatchMode);
       var jobObject = getJobObject(params, requestType);
       jobObject.type = requestType;

--- a/lib/client/signalflow/websocket_message_parser.js
+++ b/lib/client/signalflow/websocket_message_parser.js
@@ -1,19 +1,24 @@
 'use strict';
-// Copyright (C) 2016 SignalFx, Inc. All rights reserved.
+// Copyright (C) 2016-2017 SignalFx, Inc. All rights reserved.
 
 var base64js = require('base64-js');
 var BigNumber = require('bignumber.js');
-// unfortunately, bigNumber will throw an error on constructors with more than 15 significant digits, which is certainly possible in JS.
+// unfortunately, bigNumber will throw an error on constructors with more than
+// 15 significant digits, which is certainly possible in JS.
 BigNumber.config({ ERRORS: false });
+var pako = require('pako');
+var TextEncoding = require('text-encoding');
+
+var textDecoder = new TextEncoding.TextDecoder('utf-8');
 
 var hiMult = Math.pow(2, 32);
-
-var msgFormats = {
+var binaryHeaderLength = 20;
+var binaryHeaderFormats = {
   1: [
     //.0                   1                   2                   3
     //.0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     //+---------------+---------------+-------------------------------+
-    //| Version       | Message type  | (Reserved)                    |
+    //| Version       | Message type  | Flags         | (Reserved)    |
     //+---------------+---------------+-------------------------------+
     //|        Channel name (fixed 16 bytes, right-NUL-padded)        |
     //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
@@ -22,6 +27,91 @@ var msgFormats = {
     //|                   Channel name (continued)                    |
     //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
     //|                   Channel name (continued)                    |
+    //+---------------------------------------------------------------+
+    {
+      label: 'version',
+      type: 'Uint',
+      size: 1
+    },
+    {
+      label: 'type',
+      type: 'Uint',
+      size: 1
+    },
+    {
+      label: 'flags',
+      type: 'Uint',
+      size: 1
+    },
+    {
+      label: null,
+      size: 1
+    },
+    {
+      label: 'channel',
+      type: 'string',
+      size: 16
+    }
+  ],
+
+
+  2: [
+    //.0                   1                   2                   3
+    //.0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    //+---------------+---------------+-------------------------------+
+    //|            Version            | Message type  | Flags         |
+    //+---------------+---------------+-------------------------------+
+    //|        Channel name (fixed 16 bytes, right-NUL-padded)        |
+    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
+    //|                   Channel name (continued)                    |
+    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
+    //|                   Channel name (continued)                    |
+    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
+    //|                   Channel name (continued)                    |
+    //+---------------------------------------------------------------+
+    {
+      label: 'version',
+      type: 'Uint',
+      size: 2
+    },
+    {
+      label: 'type',
+      type: 'Uint',
+      size: 1
+    },
+    {
+      label: 'flags',
+      type: 'Uint',
+      size: 1
+    },
+    {
+      label: 'channel',
+      type: 'string',
+      size: 16
+    }
+  ]
+};
+
+/**
+ * Stream message types.
+ */
+var binaryMessageTypes = {
+  1: 'control-message',
+  2: 'message',
+  3: 'event',
+  4: 'metadata',
+  5: 'data',
+  6: 'error',
+  7: 'authenticated',
+  8: 'computation-started',
+  9: 'estimation',
+  10: 'expired-tsid'
+};
+
+var binaryDataMessageFormats = {
+  1: [
+    //.0                   1                   2                   3
+    //.0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     //+---------------------------------------------------------------+
     //|           Data batch logical millisecond timestamp            |
     //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
@@ -38,25 +128,6 @@ var msgFormats = {
     //| Payload data continued ...                                    |
     //+---------------------------------------------------------------+
     {
-      label: 'version',
-      type: 'Uint',
-      size: 1
-    },
-    {
-      label: 'messageType',
-      type: 'Uint',
-      size: 1
-    },
-    {
-      label: null,
-      size: 2
-    },
-    {
-      label: 'channel',
-      type: 'string',
-      size: 16
-    },
-    {
       label: 'timestampMs1',
       type: 'Uint',
       size: 4
@@ -72,19 +143,10 @@ var msgFormats = {
       size: 4
     }
   ],
-  2: [
+
+  512: [
     //.0                   1                   2                   3
     //.0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    //+---------------+---------------+-------------------------------+
-    //|            Version            | Message type  | (Reserved)    |
-    //+---------------+---------------+-------------------------------+
-    //|        Channel name (fixed 16 bytes, right-NUL-padded)        |
-    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
-    //|                   Channel name (continued)                    |
-    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
-    //|                   Channel name (continued)                    |
-    //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
-    //|                   Channel name (continued)                    |
     //+---------------------------------------------------------------+
     //|           Data batch logical millisecond timestamp            |
     //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
@@ -104,25 +166,6 @@ var msgFormats = {
     //+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -+
     //| Payload data continued ...                                    |
     //+---------------------------------------------------------------+
-    {
-      label: 'version',
-      type: 'Uint',
-      size: 2
-    },
-    {
-      label: 'messageType',
-      type: 'Uint',
-      size: 1
-    },
-    {
-      label: null,
-      size: 1
-    },
-    {
-      label: 'channel',
-      type: 'string',
-      size: 16
-    },
     {
       label: 'timestampMs1',
       type: 'Uint',
@@ -151,117 +194,189 @@ var msgFormats = {
   ]
 };
 
+/**
+ * Convert the given Uint8 array into a SignalFx Snowflake ID.
+ */
 function getSnowflakeIdFromUint8Array(Uint8Arr) {
-  //packaged lib uses base64 not base64URL, so swap the different chars
+  // packaged lib uses base64 not base64URL, so swap the different chars
   return base64js.fromByteArray(Uint8Arr).substring(0, 11).replace(/\+/g, '-').replace(/\//g, '_');
 }
 
-function parseWebSocketMessage(msg, knownComputations) {
-  if (msg.data && msg.data.byteLength) {
-    var msgObject = {
-      type: 'data'
-    };
+/**
+ * Extract fields from the given DataView following a specific a binary format
+ * specification into the given target object.
+ */
+function extractBinaryFields(target, spec, data) {
+  var offset = 0;
 
-    var view = new DataView(msg.data);
-    var version = view.getUint8(0);
-    var offset = 0;
-
-    for (var x = 0; x < msgFormats[version].length; x++) {
-      var item = msgFormats[version][x];
-      if (item.label) {
-        if (item.type === 'string') {
-          msgObject[item.label] = '';
-          for (var y = 0; y < item.size; y++) {
-            var chr = view.getUint8(offset + y);
-            if (chr === 0) {
-              break;
-            }
-            msgObject[item.label] += String.fromCharCode(chr);
-          }
-        } else {
-          msgObject[item.label] = view['get' + item.type + (item.size * 8)](offset);
-        }
+  for (var x = 0; x < spec.length; x++) {
+    var item = spec[x];
+    if (item.label) {
+      if (item.type === 'string') {
+        var bytes = new DataView(data.buffer, offset, item.size);
+        var str = textDecoder.decode(bytes);
+        target[item.label] = str.replace(/\0/g, '');
+      } else {
+        target[item.label] = data['get' + item.type + (item.size * 8)](offset);
       }
-      offset += item.size;
     }
+    offset += item.size;
+  }
 
-    msgObject.logicalTimestampMs = (msgObject.timestampMs1 * hiMult) + msgObject.timestampMs2;
-    delete msgObject.timestampMs1;
-    delete msgObject.timestampMs2;
+  return offset;
+}
 
-    if (typeof msgObject.maxDelayMs1 !== 'undefined' && typeof msgObject.maxDelayMs2 !== 'undefined') {
-      msgObject.maxDelayMs = (msgObject.maxDelayMs1 * hiMult) + msgObject.maxDelayMs2;
-      delete msgObject.maxDelayMs1;
-      delete msgObject.maxDelayMs2;
-    }
+/**
+ * Parse a binary WebSocket message.
+ *
+ * Binary messages have a 20-byte header (binaryHeaderLength), followed by a
+ * body. Depending on the flags set in the header, the body of the message may
+ * be compressed, so it needs to be decompressed before being parsed.
+ *
+ * Finally, depending on the message type and the 'json' flag, the body of the
+ * message may be a JSON string, or a binary format. As of now, only data batch
+ * messages encode their body in binary, as per the binaryDataMessageFormats
+ * defined above.
+ */
+function parseBinaryMessage(data, knownComputations) {
+  var msg = {};
 
-    var bigNumberRequested = false;
-    if (typeof knownComputations[msgObject.channel] !== 'undefined' && knownComputations[msgObject.channel].params) {
-      bigNumberRequested = knownComputations[msgObject.channel].params.bigNumber;
-    }
+  var header = new DataView(data, 0, binaryHeaderLength);
+  var version = header.getUint8(0);
+  extractBinaryFields(msg, binaryHeaderFormats[version], header);
 
-    var values = [];
-
-    msgObject.data = values;
-
-    for (var dataPointCount = 0; dataPointCount < msgObject.count; dataPointCount++) {
-      var type = view.getUint8(offset);
-      offset++;
-      var tsidBytes = [];
-      for (var tsidByteIndex = 0; tsidByteIndex < 8; tsidByteIndex++) {
-        tsidBytes.push(view.getUint8(offset));
-        offset++;
-      }
-      var tsId = getSnowflakeIdFromUint8Array(tsidBytes);
-
-      var val = null;
-      if (type === 0) {
-        // NULL_TYPE, nothing to do
-      } else if (type === 1) {
-        // LONG_TYPE
-
-        // get MSB for twos complement to determine sign
-        var isNegative = view.getUint32(offset) >>> 31 > 0;
-        if (isNegative) {
-          // twos complement manual handling, because we cannot do Int64.
-          // must do >>> 0 to prevent bit flips from turning into signed integers.
-          val = new BigNumber(hiMult).times(~view.getUint32(offset) >>> 0).plus(~view.getUint32(offset + 4) >>> 0).plus(1).times(-1);
-        } else {
-          val = (new BigNumber(view.getUint32(offset))).times(hiMult).plus(view.getUint32(offset + 4));
-        }
-
-        if (!bigNumberRequested) {
-          val = val.toNumber();
-        }
-      } else if (type === 2) {
-        // DOUBLE_TYPE
-        val = view.getFloat64(offset);
-        if (bigNumberRequested) {
-          val = new BigNumber(val);
-        }
-      } else if (type === 3) {
-        // INT_TYPE
-        val = view.getUint32(offset + 4);
-        if (bigNumberRequested) {
-          val = new BigNumber(val);
-        }
-      }
-
-      offset += 8;
-      values.push({tsId: tsId, value: val});
-    }
-
-    delete msgObject.count;
-    return msgObject;
-  } else if (msg.type) {
-    return JSON.parse(msg.data);
-  } else {
-    console.warn('Unrecognized websocket message.');
+  var type = binaryMessageTypes[msg.type];
+  if (type === undefined) {
+    console.warn('Unknown binary message type ' + msg.type);
     return null;
+  }
+  msg.type = type;
+
+  var bigNumberRequested = false;
+  if (typeof knownComputations[msg.channel] !== 'undefined' && knownComputations[msg.channel].params) {
+    bigNumberRequested = knownComputations[msg.channel].params.bigNumber;
+  }
+
+  var compressed = msg.flags & (1 << 0);
+  var json = msg.flags & (1 << 1);
+
+  if (compressed) {
+    // Decompress the message body if necessary.
+    data = new DataView(pako.ungzip(new Uint8Array(data, binaryHeaderLength)).buffer);
+  } else {
+    data = new DataView(data, binaryHeaderLength);
+  }
+
+  if (json) {
+    var decoded = textDecoder.decode(data);
+    return JSON.parse(decoded);
+  }
+
+  switch (msg['type']) {
+    case 'data':
+      return parseBinaryDataMessage(msg, data, bigNumberRequested);
+    default:
+      console.warn('Unsupported binary "' + msg['type'] + '" message');
+      return null;
   }
 }
 
+/**
+ * Parse a binary data message body.
+ *
+ * Parse the binary-encoded information and datapoints of a data batch message.
+ */
+function parseBinaryDataMessage(msg, data, bigNumberRequested) {
+  var offset = extractBinaryFields(msg, binaryDataMessageFormats[msg['version']], data);
+
+  msg.logicalTimestampMs = (msg.timestampMs1 * hiMult) + msg.timestampMs2;
+  delete msg.timestampMs1;
+  delete msg.timestampMs2;
+
+  if (typeof msg.maxDelayMs1 !== 'undefined' && typeof msg.maxDelayMs2 !== 'undefined') {
+    msg.maxDelayMs = (msg.maxDelayMs1 * hiMult) + msg.maxDelayMs2;
+    delete msg.maxDelayMs1;
+    delete msg.maxDelayMs2;
+  }
+
+  var values = [];
+  msg.data = values;
+
+  for (var dataPointCount = 0; dataPointCount < msg.count; dataPointCount++) {
+    var type = data.getUint8(offset);
+    offset++;
+
+    var tsidBytes = [];
+    for (var tsidByteIndex = 0; tsidByteIndex < 8; tsidByteIndex++) {
+      tsidBytes.push(data.getUint8(offset));
+      offset++;
+    }
+    var tsId = getSnowflakeIdFromUint8Array(tsidBytes);
+
+    var val = null;
+    if (type === 0) {
+      // NULL_TYPE, nothing to do
+    } else if (type === 1) {
+      // LONG_TYPE
+
+      // get MSB for twos complement to determine sign
+      var isNegative = data.getUint32(offset) >>> 31 > 0;
+      if (isNegative) {
+        // twos complement manual handling, because we cannot do Int64.
+        // must do >>> 0 to prevent bit flips from turning into signed integers.
+        val = (new BigNumber(hiMult)
+               .times(~data.getUint32(offset) >>> 0)
+               .plus(~data.getUint32(offset + 4) >>> 0)
+               .plus(1)
+               .times(-1));
+      } else {
+        val = (new BigNumber(data.getUint32(offset))
+               .times(hiMult)
+               .plus(data.getUint32(offset + 4)));
+      }
+
+      if (!bigNumberRequested) {
+        val = val.toNumber();
+      }
+    } else if (type === 2) {
+      // DOUBLE_TYPE
+      val = data.getFloat64(offset);
+      if (bigNumberRequested) {
+        val = new BigNumber(val);
+      }
+    } else if (type === 3) {
+      // INT_TYPE
+      val = data.getUint32(offset + 4);
+      if (bigNumberRequested) {
+        val = new BigNumber(val);
+      }
+    }
+
+    offset += 8;
+    values.push({tsId: tsId, value: val});
+  }
+
+  delete msg.count;
+  return msg;
+}
+
+
 module.exports = {
   getSnowflakeIdFromUint8Array: getSnowflakeIdFromUint8Array,
-  parseWebSocketMessage: parseWebSocketMessage
+
+  /**
+   * Parse the given received WebSocket message into its canonical Javascript representation.
+   */
+  parseWebSocketMessage: function (msg, knownComputations) {
+    if (msg.data && msg.data.byteLength) {
+      // The presence of byteLength indicates data is an ArrayBuffer from a WebSocket data frame.
+      return parseBinaryMessage(msg.data, knownComputations);
+    } else if (msg.type) {
+      // Otherwise it's JSON in a WebSocket text frame.
+      return JSON.parse(msg.data);
+    } else {
+      console.warn('Unrecognized websocket message.');
+      return null;
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "Node.js client library for SignalFx",
   "homepage": "https://signalfx.com",
   "repository": "https://github.com/signalfx/signalfx-nodejs",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
   "dependencies": {
     "base64-js": "^1.1.2",
     "bignumber.js": "^2.3.0",
+    "pako": "^1.0.4",
     "promise": "^7.0.4",
     "protobufjs": "^4.0.0",
     "request": "^2.61.0",
     "sse.js": "^0.4.1",
+    "text-encoding": "^0.6.4",
     "winston": "^1.0.1",
     "ws": "^1.1.0"
   },

--- a/test/signalflow/websocket_message_parser.js
+++ b/test/signalflow/websocket_message_parser.js
@@ -245,3 +245,84 @@ describe('it should properly unpack positive binary integer messages with small 
     expect(outputMsg.data[0].value.toString()).to.equal('42');
   });
 });
+
+describe('it should properly unpack binary compressed json messages', function () {
+  var originalMsg = [1, 1, 3, 0, 82, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     120, 156, 171, 86, 42, 169, 44, 72, 85, 82, 176, 82, 80, 74, 206, 207, 43, 41, 202, 207, 209, 205, 77, 45, 46, 78,
+                     76, 79, 85, 210, 81, 80, 74, 45, 75, 205, 43, 81, 2, 202, 121, 249, 59, 197, 7, 135, 56, 6, 133, 128, 68, 51, 18,
+                     243, 82, 114, 82, 65, 194, 142, 48, 224, 156, 175, 84, 11, 0, 128, 222, 22, 125];
+  var arrBuff = new ArrayBuffer(originalMsg.length);
+  var typedArr = new Uint8Array(arrBuff);
+  originalMsg.forEach(function (val, idx) {
+    typedArr[idx] = val;
+  });
+
+  var outputMsg = wsmh.parseWebSocketMessage({data: arrBuff}, {
+    R0: {
+      params: {
+      }
+    }
+  });
+
+  it('should unpack the 1-byte version correctly', function () {
+    expect(outputMsg.version).to.equal(1);
+  });
+
+  it('should unpack the 1-byte message type correctly', function () {
+    expect(outputMsg.type).to.equal('control-message');
+  });
+
+  it('should unpack the 1-byte flags correctly', function () {
+    expect(outputMsg.flags).to.equal(3);
+  });
+
+  it('should unpack the channel name correctly', function () {
+    expect(outputMsg.channel).to.equal('R0');
+  });
+
+  it('should unpack the json message body correctly', function () {
+    expect(outputMsg.event).to.equal('JOB_START');
+    expect(outputMsg.handle).to.equal('AAAAAAAAACo');
+  });
+});
+
+describe('it should properly unpack binary compressed data messages', function () {
+  var originalMsg = [2, 0, 5, 1, 82, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     120, 156, 99, 96, 96, 96, 98, 102, 128, 0, 45, 8, 197, 114, 137, 9,
+                     42, 160, 237, 192, 41, 183, 35, 240, 117, 171, 60, 0, 33, 132, 4, 50];
+  var arrBuff = new ArrayBuffer(originalMsg.length);
+  var typedArr = new Uint8Array(arrBuff);
+  originalMsg.forEach(function (val, idx) {
+    typedArr[idx] = val;
+  });
+
+  var outputMsg = wsmh.parseWebSocketMessage({data: arrBuff}, {
+    R0: {
+      params: {
+      }
+    }
+  });
+
+  it('should unpack the 2-byte version correctly', function () {
+    expect(outputMsg.version).to.equal(512);
+  });
+
+  it('should unpack the 1-byte message type correctly', function () {
+    expect(outputMsg.type).to.equal('data');
+  });
+
+  it('should unpack the 1-byte flags correctly', function () {
+    expect(outputMsg.flags).to.equal(1);
+  });
+
+  it('should detect the correct number of datapoints in binary data batch', function () {
+    expect(outputMsg.count).to.equal(2);
+  });
+
+  it('should decode the datapoints correctly from the binary data batch', function () {
+    expect(outputMsg.data[0].tsId).to.equal('AAAAAAAAACo');
+    expect(outputMsg.data[0].value).to.equal(1234);
+    expect(outputMsg.data[1].tsId).to.equal('AAAAAAAAACs');
+    expect(outputMsg.data[1].value).to.equal(3.14);
+  });
+});


### PR DESCRIPTION
Cliff notes:
* New dependency on `pako` for the GZIP decompression
* New dependency on `text-encoding` shim for decoding UTF-8 strings out of binary buffers
* Refactoring of WebSocket message parsing:
  * Split binary format definitions of the binary message header and the binary data batch message format
  * Add support for `compressed` and `json` message flags (set on the `flags` byte of the binary message header)
  * Decompress binary message body if necessary, as per the `compressed` flag
  * Decode binary message body as a UTF-8 JSON string, if mandated by the `json` flag
  * Otherwise decode binary message body as per message type, for now only data batches are sent with a binary body
* Bump version to 4.0.22