### PR TITLE
Fix unit tests for decoding compressed socket messages

### DIFF
--- a/lib/client/signalflow/websocket_message_parser.js
+++ b/lib/client/signalflow/websocket_message_parser.js
@@ -269,7 +269,11 @@ function parseBinaryMessage(data, knownComputations) {
 
   if (json) {
     var decoded = textDecoder.decode(data);
-    return JSON.parse(decoded);
+    var body = JSON.parse(decoded);
+    Object.keys(body).forEach(function (k) {
+      msg[k] = body[k];
+    });
+    return msg;
   }
 
   switch (msg['type']) {

--- a/test/signalflow/websocket_message_parser.js
+++ b/test/signalflow/websocket_message_parser.js
@@ -264,8 +264,20 @@ describe('it should properly unpack binary compressed json messages', function (
     }
   });
 
+  it('should unpack the 1-byte version correctly', function () {
+    expect(outputMsg.version).to.equal(1);
+  });
+
   it('should unpack the 1-byte message type correctly', function () {
     expect(outputMsg.type).to.equal('control-message');
+  });
+
+  it('should unpack the 1-byte flags correctly', function () {
+    expect(outputMsg.flags).to.equal(3);
+  });
+
+  it('should unpack the channel name correctly', function () {
+    expect(outputMsg.channel).to.equal('R0');
   });
 
   it('should unpack the json message body correctly', function () {
@@ -274,44 +286,55 @@ describe('it should properly unpack binary compressed json messages', function (
   });
 });
 
-// TODO : this test is not working and causes the suite to not complete.  fixme later
-//describe('it should properly unpack binary compressed data messages', function () {
-//  var originalMsg = [2, 0, 5, 1, 82, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//                     120, 156, 99, 96, 96, 96, 98, 102, 128, 0, 45, 8, 197, 114, 137, 9,
-//                     42, 160, 237, 192, 41, 183, 35, 240, 117, 171, 60, 0, 33, 132, 4, 50];
-//  var arrBuff = new ArrayBuffer(originalMsg.length);
-//  var typedArr = new Uint8Array(arrBuff);
-//  originalMsg.forEach(function (val, idx) {
-//    typedArr[idx] = val;
-//  });
-//
-//  var outputMsg = wsmh.parseWebSocketMessage({data: arrBuff}, {
-//    R0: {
-//      params: {
-//      }
-//    }
-//  });
-//
-//  it('should unpack the 2-byte version correctly', function () {
-//    expect(outputMsg.version).to.equal(512);
-//  });
-//
-//  it('should unpack the 1-byte message type correctly', function () {
-//    expect(outputMsg.type).to.equal('data');
-//  });
-//
-//  it('should unpack the 1-byte flags correctly', function () {
-//    expect(outputMsg.flags).to.equal(1);
-//  });
-//
-//  it('should detect the correct number of datapoints in binary data batch', function () {
-//    expect(outputMsg.count).to.equal(2);
-//  });
-//
-//  it('should decode the datapoints correctly from the binary data batch', function () {
-//    expect(outputMsg.data[0].tsId).to.equal('AAAAAAAAACo');
-//    expect(outputMsg.data[0].value).to.equal(1234);
-//    expect(outputMsg.data[1].tsId).to.equal('AAAAAAAAACs');
-//    expect(outputMsg.data[1].value).to.equal(3.14);
-//  });
-//});
+describe('it should properly unpack binary compressed data messages', function () {
+  var originalMsg = [2, 0, 5, 1, 82, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     120, 156, 99, 96, 0, 1, 150, 75, 96, 138, 65, 32, 3, 72, 48, 49,
+                     67, 56, 12, 92, 80, 90, 139, 9, 202, 224, 118, 224, 148, 219, 17,
+                     248, 186, 85, 30, 0, 74, 190, 4, 148];
+  var arrBuff = new ArrayBuffer(originalMsg.length);
+  var typedArr = new Uint8Array(arrBuff);
+  originalMsg.forEach(function (val, idx) {
+    typedArr[idx] = val;
+  });
+
+  var outputMsg = wsmh.parseWebSocketMessage({data: arrBuff}, {
+    R0: {
+      params: {
+      }
+    }
+  });
+
+  it('should unpack the 2-byte version correctly', function () {
+    expect(outputMsg.version).to.equal(512);
+  });
+
+  it('should unpack the 1-byte message type correctly', function () {
+    expect(outputMsg.type).to.equal('data');
+  });
+
+  it('should unpack the 1-byte flags correctly', function () {
+    expect(outputMsg.flags).to.equal(1);
+  });
+
+  it('should unpack the correct data batch timestamp', function () {
+    expect(outputMsg.logicalTimestampMs).to.equal(1234);
+  });
+
+  it('should unpack the correct data batch max delay', function () {
+    expect(outputMsg.maxDelayMs).to.equal(4200);
+  });
+
+  it('should detect the correct number of datapoints in binary data batch', function () {
+    expect(outputMsg.data.length).to.equal(2);
+  });
+
+  it('should decode the first datapoint correctly from the binary data batch', function () {
+    expect(outputMsg.data[0].tsId).to.equal('AAAAAAAAAAo');
+    expect(outputMsg.data[0].value).to.equal(42);
+  });
+
+  it('should decode the second datapoint correctly from the binary data batch', function () {
+    expect(outputMsg.data[1].tsId).to.equal('AAAAAAAAAAs');
+    expect(outputMsg.data[1].value).to.equal(3.14);
+  });
+});


### PR DESCRIPTION
The binary data in the test case was incorrect leading to a decoding
error that was silently swallowed.

Also fix the test of the decoding a non-data compressed message, as the
header fields of the message should be included in the returned object,
not just the body fields.