### PR TITLE
Bugfix/queue fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Object `options` is an optional map and may contains following fields:
 + **dimensions** - object, pre-defined dimensions for each datapoint and event. This object has key-value format `{ dimension_name: dimension_value, ...}`
 + **ingestEndpoint** -  string, custom url to send datapoints in format http://custom.domain/api/path
 + **timeout** - number, sending datapoints timeout in ms (default is 1000ms)
-+ **batchSize** - number, batch size to group sending datapoints 
++ **batchSize** - number, batch size to group sending datapoints (default is 300)
++ **minBatchSize** - number, fewest datapoints that will be sent at a time, however all queued datapoints can be sent by calling `client.flush()` (default is 0)
 + **userAgents** - array of strings, items from this array will be added to 'user-agent' header separated by comma
 + **proxy** - string, defines an address and credentials for sending metrics through a proxy server. The string should have the following format `http://<USER>:<PASSWORD>@<HOST>:<PORT>`
 

--- a/lib/client/conf.js
+++ b/lib/client/conf.js
@@ -5,7 +5,8 @@
 exports.DEFAULT_INGEST_ENDPOINT = 'https://ingest.signalfx.com';
 exports.DEFAULT_API_ENDPOINT = 'https://api.signalfx.com';
 exports.DEFAULT_SIGNALFLOW_WEBSOCKET_ENDPOINT = 'wss://stream.signalfx.com';
-exports.DEFAULT_BATCH_SIZE = 300;// Will wait for this many requests before posting
+exports.DEFAULT_BATCH_SIZE = 300; // Will not send more than this many requests at a time
+exports.DEFAULT_MIN_BATCH_SIZE = 0; // Will wait for this many requests before posting
 exports.DEFAULT_TIMEOUT = 1000; // Default timeout is 1s
 
 // Whether to request SignalFlow WebSocket message compression.

--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -46,6 +46,7 @@ function SignalFxClient(apiToken, options) {
   this.rawData = [];
   this.rawEvents = [];
   this.queue = [];
+  this.asyncSendPromise = Promise.resolve();
 
   this.loadAWSUniqueId = new Promise(function (resolve) {
     if (!_this.enableAmazonUniqueId) {
@@ -103,7 +104,11 @@ SignalFxClient.prototype.send = function (data) {
   return this.loadAWSUniqueId
     .then(function () {
       _this.processingData();
-      return _this.startAsyncSend();
+      // Do not send until the previous send had finished
+      _this.asyncSendPromise = _this.asyncSendPromise.then(function () {
+        return _this.startAsyncSend();
+      });
+      return _this.asyncSendPromise;
     });
 };
 
@@ -237,15 +242,19 @@ SignalFxClient.prototype.startAsyncSend = function () {
     datapointsList.push(_this.queue.shift());
   }
 
+  var sendPromise = Promise.resolve();
   if (datapointsList.length > 0) {
     var dataToSend = _this._batchData(datapointsList);
     if (dataToSend && dataToSend.length > 0) {
       var url = _this.ingestEndpoint + '/' + _this.INGEST_ENDPOINT_SUFFIX;
-      return _this.post(dataToSend, url, _this.getHeaderContentType());
+      sendPromise = _this.post(dataToSend, url, _this.getHeaderContentType());
     }
   }
-  return new Promise(function (resolve) {
-    resolve(null);
+  return sendPromise.then(function () {
+    // Continue sending until we flush the queue
+    return _this.queue.length > 0
+      ? _this.startAsyncSend()
+      : Promise.resolve();
   });
 };
 

--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -38,6 +38,7 @@ function SignalFxClient(apiToken, options) {
   this.ingestEndpoint = params.ingestEndpoint || conf.DEFAULT_INGEST_ENDPOINT;
   this.timeout = params.timeout || conf.DEFAULT_TIMEOUT;
   this.batchSize = Math.max(1, (params.batchSize ? params.batchSize : conf.DEFAULT_BATCH_SIZE));
+  this.minBatchSize = Math.max(0, (params.minBatchSize ? params.minBatchSize : conf.DEFAULT_MIN_BATCH_SIZE));
   this.userAgents = params.userAgents || null;
   this.globalDimensions = params.dimensions || {};
   this.enableAmazonUniqueId = params.enableAmazonUniqueId || false;
@@ -110,6 +111,14 @@ SignalFxClient.prototype.send = function (data) {
       });
       return _this.asyncSendPromise;
     });
+};
+
+SignalFxClient.prototype.flush = function () {
+  var _this = this;
+  _this.asyncSendPromise = _this.asyncSendPromise.then(function () {
+    return _this.startAsyncSend(true);
+  });
+  return _this.asyncSendPromise;
 };
 
 SignalFxClient.prototype.processingData = function () {
@@ -234,8 +243,16 @@ SignalFxClient.prototype._encodeEvent = function (event) {
   throw new Error('Subclasses should implement this!');
 };
 
-SignalFxClient.prototype.startAsyncSend = function () {
+
+SignalFxClient.prototype.startAsyncSend = function (flush) {
   var _this = this;
+
+  // Unless we are flushing the queue, we early return
+  // if there are not enough items in the queue.
+  if (!flush && _this.queue.length < _this.minBatchSize) {
+    return Promise.resolve();
+  }
+
   // Send post request in separate thread
   var datapointsList = [];
   while (_this.queue.length !== 0 && datapointsList.length < _this.batchSize) {
@@ -253,7 +270,7 @@ SignalFxClient.prototype.startAsyncSend = function () {
   return sendPromise.then(function () {
     // Continue sending until we flush the queue
     return _this.queue.length > 0
-      ? _this.startAsyncSend()
+      ? _this.startAsyncSend(flush)
       : Promise.resolve();
   });
 };

--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -1,5 +1,7 @@
 'use strict';
 // Copyright (C) 2015 SignalFx, Inc. All rights reserved.
+// Copyright 2017 Nike, Inc.  Nike, Inc. contributions to this file
+// are licensed for use under the Apache-2.0 license.
 
 var request = require('request'); // Use for create post request
 var winston = require('winston'); // Logging library

--- a/test/ingest/signalfx.js
+++ b/test/ingest/signalfx.js
@@ -1,5 +1,7 @@
 'use strict';
 // Copyright (C) 2015 SignalFx, Inc. All rights reserved.
+// Copyright 2017 Nike, Inc.  Nike, Inc. contributions to this file
+// are licensed for use under the Apache-2.0 license.
 
 var sinon = require('sinon');
 var mockery = require('mockery');

--- a/test/ingest/signalfx.js
+++ b/test/ingest/signalfx.js
@@ -105,6 +105,10 @@ describe('SignalFx client library (Protobuf mode)', function () {
     signalFx = require('../../lib/signalfx');
   });
 
+  beforeEach(function () {
+    requestStub.reset();
+  });
+
   after(function () {
     mockery.disable();
     mockery.deregisterAll();
@@ -224,6 +228,26 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
   });
 
+  it('promise all datapoints being sent, even if they are batched', function () {
+    requestStub.yields(null, {statusCode: 200}, 'OK');
+
+    var token = 'my token';
+    var client = new signalFx.Ingest(token, { batchSize: 1 });
+
+    var gauges = [{
+      metric: 'test.cpu',
+      value: 10
+    }, {
+      metric: 'test.cpu',
+      value: 11
+    }];
+
+    this.timeout(2020);
+    return client.send({gauges: gauges})
+      .then(function () {
+        requestStub.calledTwice.should.be.equal(true);
+      });
+  });
 
   it('Send event', function (done) {
     requestStub.yields(null, {statusCode: 200}, 'OK');


### PR DESCRIPTION
I was digging around the code here for an unrelated issue, and found that the queue implementation had a few issues that this PR addresses.

Issues are as follows:
1) The send promise does not guarantee that all datapoints send will be sent by the time that the promise resolves.  This is troublesome within an environment like AWS Lambda, which will freeze the process when the event loop is empty--which means that events could be lost.

2) It's possible that datapoints can be eternally never sent.  This is less likely with the default config, but _more_ likely if someone lowers the batch number to send items "more quickly."  As an example, say I set the batch size to 10, but my average send count is 20 datapoints.  In this case, each send will send exactly 10 datapoints, leaving 10 left in the queue.  There is no mechanism to flush the queue, so my queue will build forever.

3) Batching can only set a _maximum_ number of datapoints to send, not a minimum, so in many cases, the batching could provide no fewer requests sent.  I've added a `minBatchSize` config item (which is sent to 1 for backwards compatibility), but could be used to make sure that items are _not_ sent until there are a minimum number of items in the queue.

This PR makes sure that there's always exactly one sending promise at a time, that will always resolve when the sender's events have been sent.  Also, a `flush` has been provided to clear out the queue if needed.