### PR TITLE
Updated default timeout

### DIFF
--- a/lib/client/conf.js
+++ b/lib/client/conf.js
@@ -6,7 +6,7 @@ exports.DEFAULT_INGEST_ENDPOINT = 'https://ingest.signalfx.com';
 exports.DEFAULT_API_ENDPOINT = 'https://api.signalfx.com';
 exports.DEFAULT_SIGNALFLOW_WEBSOCKET_ENDPOINT = 'wss://stream.signalfx.com';
 exports.DEFAULT_BATCH_SIZE = 300;// Will wait for this many requests before posting
-exports.DEFAULT_TIMEOUT = 1000; // Default timeout is 1s
+exports.DEFAULT_TIMEOUT = 5000; // Default timeout is 5s
 
 // Whether to request SignalFlow WebSocket message compression.
 exports.COMPRESS_SIGNALFLOW_WEBSOCKET_MESSAGES = true;


### PR DESCRIPTION
Changed default timeout value to 5 seconds so that it matches the Python and Go libraries.