### PR TITLE
Add support for custom callback for websocket.onerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,30 @@ For more information on access tokens, see the API's [Authentication Documentati
 
 ### SignalFlow 
 
+#### Configuring the Signalflow websocket endpoint
+
+If the websocket endpoint is not set manually, this library uses the ``us0`` realm by default.
+If you are not in this realm, you will need to explicitly set the
+endpoint urls above. To determine if you are in a different realm and need to
+explicitly set the endpoints, check your profile page in the SignalFx
+web application.
+
+
 #### Examples 
 
 Complete code example for executing a computation
 ```js
 var signalfx = require('signalfx');
 
+var wsCallback = function(evt) {
+    console.log('Hello, I'm a custom callback: ' + evt);
+}
+
 var myToken = '[ACCESS_TOKEN]';
-var options = {'signalflowEndpoint': 'wss://stream.{REALM}.signalfx.com'};
+var options = {'signalflowEndpoint': 'wss://stream.{REALM}.signalfx.com',
+               'apiEndpoint': 'https://api.{REALM}.signalfx.com',
+               'webSocketErrorCallback': wsCallback
+              };
 
 var client = new signalfx.SignalFlow(myToken, options);
 
@@ -240,7 +256,13 @@ var handle = client.execute({
 handle.stream(function(err, data) { console.log(data); });
 ```
 
-Please note that a token created via the REST API is necessary to use this API.  API Access tokens intended for ingest are not allowed.
+Object `options` is an optional map and may contains following fields:
++ **signalflowEndpoint** - string, `wss://stream.us0.signalfx.com` by default. Override this if you are in a different realm than `us0`.
++ **apiEndpoint** - string, `https://api.us0.signalfx.com` by default. Override this if you are in a different realm than `us0`.
++ **webSockerErrorCallback** - function, Throws an Error event by default. Override this if you want to handle a websocket error differently.
+
+**Note**: A token created via the REST API is necessary to use this API.  API Access tokens intended for ingest are not allowed.
+
 
 #### API Options
 

--- a/lib/client/signalflow/request_manager.js
+++ b/lib/client/signalflow/request_manager.js
@@ -15,16 +15,32 @@ var conf = require('../conf');
 var SSE = require('sse.js');
 
 
-function RequestManager(endPoint) {
+function RequestManager(options) {
   var awaitingKeepaliveConfirmation = false;
   var knownComputations = {};
   var requestIdIndex = 0;
   var maxJobCount = 10000;
   var authToken = null;
   var sfxEndpoint = conf.DEFAULT_API_ENDPOINT; // TODO : SSE support?
-  var wsEndpoint = endPoint || conf.DEFAULT_SIGNALFLOW_WEBSOCKET_ENDPOINT;
+  var wsEndpoint = conf.DEFAULT_SIGNALFLOW_WEBSOCKET_ENDPOINT;
   var pendingWSRequests = [];
   var wsConnectionOpen = false;
+
+  var socketError = function (evt) {
+    throw new Error('Socket error: ' + evt);
+  };
+
+  if (options && options.signalflowEndpoint) {
+    wsEndpoint = options.signalflowEndpoint;
+  }
+
+  if (options && options.apiEndpoint) {
+    sfxEndpoint = options.apiEndpoint;
+  }
+
+  if (options && options.webSocketErrorCallback && options.webSocketErrorCallback instanceof Function) {
+    socketError = options.webSocketErrorCallback;
+  }
 
   //move me to constants
   var transports = {
@@ -154,6 +170,7 @@ function RequestManager(endPoint) {
       activeSocket = new WebSocket(wsEndpoint + '/v2/signalflow/connect');
       activeSocket.binaryType = 'arraybuffer';
       activeSocket.onmessage = onWebSocketMessage;
+      activeSocket.onerror = socketError;
       activeSocket.onopen = function (ev) {
         activeSocket.send(JSON.stringify({type: 'authenticate', token: authToken}));
         wsConnectionOpen = true;

--- a/lib/client/signalflow/signalflow_client.js
+++ b/lib/client/signalflow/signalflow_client.js
@@ -5,11 +5,7 @@ var RequestManager = require('./request_manager');
 
 
 function SignalflowClient(apiToken, options) {
-  var signalflowEndpoint = null;
-  if (options && options.signalflowEndpoint) {
-    signalflowEndpoint = options.signalflowEndpoint;
-  }
-  var rm = new RequestManager(signalflowEndpoint);
+  var rm = new RequestManager(options);
 
   rm.authenticate(apiToken);
 


### PR DESCRIPTION
Adds a new `option` for the signalflow client with the ability to define a custom callback for the websocket.onerror function.