### PR TITLE
Prevent network operations from by traced by the SignalFx tracer

### DIFF
--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -6,6 +6,7 @@ var winston = require('winston'); // Logging library
 var Promise = require('promise');
 
 var conf = require('../conf');
+var tracing = require('../../tracing');
 
 // Application version and name for User-Agent
 var name = 'signalfx-nodejs-client';
@@ -197,23 +198,25 @@ SignalFxClient.prototype._retrieveAWSUniqueId = function (callback) {
     proxy: this.proxy
   };
 
-  request(getOptions, function (error, response, body) {
-    if (error || response.statusCode !== 200) {
-      callback(false, '');
-      winston.error('Failed to retrieve AWS unique ID: ', response ? response.statusCode : '', body);
-    } else {
-      try {
-        var jsonBody = JSON.parse(body);
-        if (jsonBody && jsonBody.instanceId && jsonBody.region && jsonBody.accountId) {
-          var AWSUniqueId = jsonBody.instanceId + '_' + jsonBody.region + '_' + jsonBody.accountId;
-          callback(true, AWSUniqueId);
-        } else {
+  tracing.withNonReportingScope(function () {
+    request(getOptions, function (error, response, body) {
+      if (error || response.statusCode !== 200) {
+        callback(false, '');
+        winston.error('Failed to retrieve AWS unique ID: ', response ? response.statusCode : '', body);
+      } else {
+        try {
+          var jsonBody = JSON.parse(body);
+          if (jsonBody && jsonBody.instanceId && jsonBody.region && jsonBody.accountId) {
+            var AWSUniqueId = jsonBody.instanceId + '_' + jsonBody.region + '_' + jsonBody.accountId;
+            callback(true, AWSUniqueId);
+          } else {
+            callback(false, '');
+          }
+        } catch (e) {
           callback(false, '');
         }
-      } catch (e) {
-        callback(false, '');
       }
-    }
+    });
   });
 };
 
@@ -293,13 +296,15 @@ SignalFxClient.prototype.post = function (data, postUrl, contentType) {
     proxy: _this.proxy
   };
 
-  return new Promise(function (resolve, reject) {
-    request(postOptions, function (error, response, body) {
-      if (error || response.statusCode !== 200) {
-        winston.error('Failed to send datapoint: ', response ? response.statusCode : '', body, error);
-        reject(error);
-      }
-      resolve(body);
+  return tracing.withNonReportingScope(function () {
+    return new Promise(function (resolve, reject) {
+      request(postOptions, function (error, response, body) {
+        if (error || response.statusCode !== 200) {
+          winston.error('Failed to send datapoint: ', response ? response.statusCode : '', body, error);
+          reject(error);
+        }
+        resolve(body);
+      });
     });
   });
 };

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -1,0 +1,20 @@
+'use strict';
+// Copyright (C) 2020 SignalFx, Inc. All rights reserved.
+
+var tracing;
+
+try {
+  tracing = require('signalfx-tracing');
+  console.info('found signalfx-tracing library. Protecting metrics code from being traced.');
+} catch (err) {
+  tracing = {};
+}
+
+if (tracing.withNonReportingScope === undefined) {
+  console.log('signalfx-tracing not found or was an older version than 0.9.0.');
+  tracing.withNonReportingScope = function (callback) {
+    return callback();
+  };
+}
+
+module.exports = tracing;

--- a/test/ingest/signalfx.js
+++ b/test/ingest/signalfx.js
@@ -89,6 +89,7 @@ describe('Integration test (Protobuf mode)', function () {
 describe('SignalFx client library (Protobuf mode)', function () {
 
   var requestStub;
+  var tracingStub;
 
   before(function () {
     mockery.enable({
@@ -101,6 +102,12 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
     // replace the module `request` with a stub object
     mockery.registerMock('request', requestStub);
+
+    tracingStub = sinon.stub();
+    mockery.registerMock('../../tracing', { withNonReportingScope: function (callback) {
+      tracingStub(callback);
+      callback();
+    }});
 
     signalFx = require('../../lib/signalfx');
   });
@@ -155,6 +162,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
       enableAmazonUniqueId: enableAmazonUniqueId
     });
 
+    tracingStub.called.should.be.equal(true);
     client.apiToken.should.be.equal(token);
     client.AWSUniqueId.should.be.equal('instance_region_account');
     client.enableAmazonUniqueId.should.be.equal(true);
@@ -175,6 +183,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
       enableAmazonUniqueId: enableAmazonUniqueId
     });
 
+    tracingStub.called.should.be.equal(true);
     client.apiToken.should.be.equal(token);
     client.enableAmazonUniqueId.should.be.equal(false);
     client.AWSUniqueId.should.be.equal('');
@@ -218,6 +227,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
     this.timeout(2020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 2000);
@@ -246,6 +256,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
     this.timeout(1020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 1000);
@@ -268,6 +279,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
     this.timeout(1020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 1000);
@@ -290,6 +302,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
 
     this.timeout(1020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 1000);
@@ -602,6 +615,7 @@ describe('SignalFx client library (Protobuf mode)', function () {
 describe('SignalFx client library (Json mode)', function () {
 
   var requestStub;
+  var tracingStub;
 
   before(function () {
     mockery.enable({
@@ -614,6 +628,12 @@ describe('SignalFx client library (Json mode)', function () {
 
     // replace the module `request` with a stub object
     mockery.registerMock('request', requestStub);
+
+    tracingStub = sinon.stub();
+    mockery.registerMock('../../tracing', { withNonReportingScope: function (callback) {
+      tracingStub(callback);
+      callback();
+    }});
 
     signalFx = require('../../lib/signalfx');
   });
@@ -709,6 +729,7 @@ describe('SignalFx client library (Json mode)', function () {
 
     this.timeout(1020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 1000);
@@ -904,6 +925,7 @@ describe('SignalFx client library (Json mode)', function () {
 
     this.timeout(1020);
     setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
       done();
     }, 1000);


### PR DESCRIPTION
SignalFx tracer automatically instruments a lot of libraries including
some that we use in this library. This generates unnecessary and sometimes
noisy spans. This commit wraps network calls in
`tracer.withDisabledScope` wrapper to protect those calls from being
automatically traced.