### PR TITLE
Fix npm version warning - issue #54

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "genprotobuf": "pbjs -t static-module -w commonjs proto/signal_fx_protocol_buffers.proto > lib/proto/signal_fx_protocol_buffers_pb2.js"
   },
   "engines": {
-    "npm": ">=8.0.0"
+    "node": ">=8.0.0"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Npm version 8 doesn't exist, intended purpose seems to be node version 8 or greater. Fixes issue #54 