### PR TITLE
upgrade winston logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,11 @@ client.sendEvent({category: eventCategory,
             dimensions: dimensions, 
             properties:properties});
 ```
-See `example/generic_usage.js` for a complete code example for Reporting data.
+See `example/general_usage.js` for a complete code example for Reporting data.
 Set your SignalFx token and run example 
 
 ```sh
-$ node path/to/example/generic_usage.js
+$ node path/to/example/general_usage.js
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Set your SignalFx token and run example
 $ node path/to/example/general_usage.js
 ```
 
+### Log level
+The default log level is `info`.
+You can override it by setting `SFX_CLIENT_LOG_LEVEL` environment variable. Valid values are winston log levels: `error`, `warn`, `info`, `http`, `verbose`, `debug` and `silly`.
 
 ## SignalFlow API
 

--- a/lib/client/ingest/proto.js
+++ b/lib/client/ingest/proto.js
@@ -1,7 +1,7 @@
 'use strict';
 // Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
-var winston = require('winston'); // Logging library
+var logger = require('../../logger');
 
 var protocolBuffers;
 var protocolBufferEnabled = false;
@@ -9,7 +9,7 @@ try {
   protocolBuffers = require('../../proto/signal_fx_protocol_buffers_pb2').com.signalfx.metrics.protobuf;
   protocolBufferEnabled = true;
 } catch (error) {
-  winston.warn('Protocol Buffers not installed properly. ', error);
+  logger.warn('Protocol Buffers not installed properly %s', error);
   protocolBufferEnabled = false;
 }
 

--- a/lib/client/ingest/protobuf_signal_fx_client.js
+++ b/lib/client/ingest/protobuf_signal_fx_client.js
@@ -1,7 +1,7 @@
 'use strict';
 // Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
-var winston = require('winston'); // Logging library
+var logger = require('../../logger'); // Logging library
 
 var SignalFxClient = require('./signal_fx_client').SignalFxClient;
 var conf = require('../conf');
@@ -70,7 +70,7 @@ ProtoBufSignalFx.prototype._batchData = function (datapointsList) {
     var dataToSend = protocolBuffers.DataPointUploadMessage.encode(dpum);
     return dataToSend.finish();
   } catch (error) {
-    winston.error('Invalid Protobuf object', error);
+    logger.error('Invalid Protobuf object %s', error);
   }
 
   return undefined;

--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 var request = require('request'); // Use for create post request
-var winston = require('winston'); // Logging library
+var logger = require('../../logger'); // Logging library
 var Promise = require('promise');
 
 var conf = require('../conf');
@@ -202,7 +202,7 @@ SignalFxClient.prototype._retrieveAWSUniqueId = function (callback) {
     request(getOptions, function (error, response, body) {
       if (error || response.statusCode !== 200) {
         callback(false, '');
-        winston.error('Failed to retrieve AWS unique ID: ', response ? response.statusCode : '', body);
+        logger.error('Failed to retrieve AWS unique ID: %s %s', response ? response.statusCode : '', body);
       } else {
         try {
           var jsonBody = JSON.parse(body);
@@ -269,7 +269,7 @@ SignalFxClient.prototype.startAsyncEventSend = function () {
         return this.post(_this._encodeEvent(eventToSend), url, _this.getHeaderContentType());
       }
     } catch (error) {
-      winston.error('Can\'t process event: ', error);
+      logger.error('Can\'t process event: %s', error);
     }
   }
 };
@@ -300,7 +300,7 @@ SignalFxClient.prototype.post = function (data, postUrl, contentType) {
     return new Promise(function (resolve, reject) {
       request(postOptions, function (error, response, body) {
         if (error || response.statusCode !== 200) {
-          winston.error('Failed to send datapoint: ', response ? response.statusCode : '', body, error);
+          logger.error('Failed to send datapoint: %s %s %s', response ? response.statusCode : '', body, error ? error : '');
           reject(error);
         }
         resolve(body);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,17 @@
+'use strict';
+// Copyright (C) 2020 Splunk, Inc. All rights reserved.
+
+var winston = require('winston');
+
+var logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+      winston.format.splat(),
+      winston.format.simple()
+  ),
+  transports: [
+    new winston.transports.Console()
+  ]
+});
+
+module.exports = logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,7 +4,7 @@
 var winston = require('winston');
 
 var logger = winston.createLogger({
-  level: 'info',
+  level: process.env.SFX_CLIENT_LOG_LEVEL || 'info',
   format: winston.format.combine(
       winston.format.splat(),
       winston.format.simple()

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -2,16 +2,17 @@
 // Copyright (C) 2020 SignalFx, Inc. All rights reserved.
 
 var tracing;
+var logger = require('./logger');
 
 try {
   tracing = require('signalfx-tracing');
-  console.info('found signalfx-tracing library. Protecting metrics code from being traced.');
+  logger.info('found signalfx-tracing library. Protecting metrics code from being traced.');
 } catch (err) {
   tracing = {};
 }
 
 if (tracing.withNonReportingScope === undefined) {
-  console.log('signalfx-tracing not found or was an older version than 0.9.0.');
+  logger.info('signalfx-tracing not found or was an older version than 0.9.0.');
   tracing.withNonReportingScope = function (callback) {
     return callback();
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Node.js client library for SignalFx",
   "homepage": "https://signalfx.com",
   "repository": "https://github.com/signalfx/signalfx-nodejs",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "request": "^2.61.0",
     "sse.js": "^0.4.1",
     "text-encoding": "^0.6.4",
-    "winston": "^1.0.1",
+    "winston": "^3.3.3",
     "ws": "^7.1.2"
   },
   "scripts": {


### PR DESCRIPTION
This change is triggered by the necessity to update winston logging library. Its current version breaks webpack builds for some customers (and has security vulnerabilities). 

There are some breaking changes between 1.x.x we used and up to date 3.x.x.
The logger now needs to be configured (at minimum, we need to add transports to it).
I used winston simple formatter to mimic how we currently log things as closely as possible, but if we could go with json formatter, we could use some nice out-of-the-box formatters for errors. Please let me know what you think - the immediate need is to upgrade winston in order to stop breaking webpack builds, and we can always change the log format later if desired.