### PR TITLE
Remove winston logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,17 +1,38 @@
 'use strict';
 // Copyright (C) 2020 Splunk, Inc. All rights reserved.
 
-var winston = require('winston');
+var levels = {
+  error: 1,
+  info: 2,
+  warn: 3,
+  debug: 4
+};
 
-var logger = winston.createLogger({
-  level: process.env.SFX_CLIENT_LOG_LEVEL || 'info',
-  format: winston.format.combine(
-      winston.format.splat(),
-      winston.format.simple()
-  ),
-  transports: [
-    new winston.transports.Console()
-  ]
-});
+var methods = {
+  error: console.error,
+  info: console.info,
+  warn: console.warn,
+  debug: console.debug
+};
 
-module.exports = logger;
+var defaultLevel = levels[process.env.SFX_CLIENT_LOG_LEVEL || 'info'];
+
+function createLogger(level) {
+  if (defaultLevel && levels[level] > defaultLevel) {
+    return function () {};
+  }
+  return function () {
+    var method = methods[level] || console.log;
+    arguments[0] = level + ': ' + arguments[0];
+    method.apply(this, arguments);
+  };
+}
+
+module.exports = {
+  log: createLogger(defaultLevel),
+  info: createLogger('info'),
+  warn: createLogger('warn'),
+  warning: createLogger('warn'),
+  error: createLogger('error'),
+  debug: createLogger('debug')
+};


### PR DESCRIPTION
This commit removes winston logger as a dependency and replaces it with
a very simple console.log based implementation. The implementation
satisfies all current uses of the winston logger in this library.

This shaves off about 700 kilobyes un-gzipped from bundle size and
removes a few indirect dependencies which is very good for enviorments
like AWS Lambda.

This also makes it possible to build the library with esbuild which had
issues with one of it's dependencies (logform).