### PR TITLE
Fix registerlivetail request id

### DIFF
--- a/lib/client/signalflow/request_manager.js
+++ b/lib/client/signalflow/request_manager.js
@@ -403,7 +403,7 @@ function RequestManager(options) {
       requestId: requestId,
       streamController: {
         retry: function () {
-          registerLiveTail(params, callback, overrideRequestId);
+          registerLiveTail(params, callback, requestId);
         },
         stop: function () {
           stopLiveTail(requestId);


### PR DESCRIPTION
Fixes: https://signalfuse.atlassian.net/browse/BEAV-1254

**Context**

This bug first appeared in customer environment where they had a live tail session open for more than a day. After coming back to livetail there were many web sockets registered which caused the UI to break and become unusable.

these metrics are showing one example of this bug occurring, notice 20k registered sessions. 
![image](https://user-images.githubusercontent.com/61996051/125325423-c54db080-e2f5-11eb-90dd-a37f4409ed27.png)


**Steps to Reproduce**

1. Open livetail in log observer
1. Open devtools and put a breakpoint in the `setInterval` function in `authenticate` function
1. wait for keepAlive to break and copy the `activeSocket` from the scope variables, we will use this to force close the socket
1. close the socket by running `activeSocket.close()`
1. Wait for keepAlive messages and inspect the `/connect` message in devtools
1. Try to update the livetail speed to trigger new registerLiveTail calls
1. notice how there are multiple channels running at the same time