### PR TITLE
Remove info message about signalfx-tracing

### DIFF
--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -12,7 +12,6 @@ try {
 }
 
 if (tracing.withNonReportingScope === undefined) {
-  logger.info('signalfx-tracing not found or was an older version than 0.9.0.');
   tracing.withNonReportingScope = function (callback) {
     return callback();
   };


### PR DESCRIPTION
The library will be used with `splunk-otel-js`, don't want confusion regarding signalfx-tracing.