### PR TITLE
Stop existing livetail session before creating new one

### DIFF
--- a/lib/client/signalflow/request_manager.js
+++ b/lib/client/signalflow/request_manager.js
@@ -403,6 +403,7 @@ function RequestManager(options) {
       requestId: requestId,
       streamController: {
         retry: function () {
+          stopLiveTail(requestId);
           registerLiveTail(params, callback, requestId);
         },
         stop: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Node.js client library for SignalFx",
   "homepage": "https://signalfx.com",
   "repository": "https://github.com/signalfx/signalfx-nodejs",


### PR DESCRIPTION
The issue this is trying to fix is that the logs backend is seeing unusually high number of livetail registration requests from users causing many active sessions at a time.

From what I'm able to repro, if the socket disconnects and the tab is active it will try to call reconnect which will call the retry method on livetail registration without stopping the existing livetail session. This change makes sure stop is called before retry.