### PR TITLE
Bugfixed for 'null' type of msgCallback value to avoid stop rendering from the chart. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ The signalflow client can be built for usage in a browser. This is accomplished 
 
 ```
 $ npm install
-$ gulp browserify
+$ npm run build:browser
 The output can be found at ./build/signalfx.js
 ```
 

--- a/lib/client/signalflow/signalflow_client.js
+++ b/lib/client/signalflow/signalflow_client.js
@@ -32,6 +32,8 @@ function SignalflowClient(apiToken, options) {
     }
 
     function msgCallback(msg) {
+      if(!msg) return;
+
       if (msg.type === 'metadata') {
         metaDataMap[msg.tsId] = msg;
       }

--- a/lib/client/signalflow/signalflow_client.js
+++ b/lib/client/signalflow/signalflow_client.js
@@ -32,6 +32,7 @@ function SignalflowClient(apiToken, options) {
     }
 
     function msgCallback(msg) {
+      // For handling the non-object typed of the 'msg' data.
       if(!msg) return;
 
       if (msg.type === 'metadata') {


### PR DESCRIPTION
Bugs: The client side (browser) will throw an error and stop rendering the chart if the parameter of msgCallback function is 'null' or other non-object type of data, then it will throw the error since there is no 'type' attribute that "msg" can be accessed.

Bugfixed for 'null' type of msgCallback value to avoid stop to render on the chart by adding a type checker function:
```
    if(!msg) return;
```