### PR TITLE
Use splice() instead of repeated shift() to remove from queue

### DIFF
--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -229,10 +229,7 @@ SignalFxClient.prototype._encodeEvent = function (_event) {
 SignalFxClient.prototype.startAsyncSend = function () {
   var _this = this;
   // Send post request in separate thread
-  var datapointsList = [];
-  while (_this.queue.length !== 0 && datapointsList.length < _this.batchSize) {
-    datapointsList.push(_this.queue.shift());
-  }
+  var datapointsList = _this.queue.splice(0, _this.batchSize);
 
   if (datapointsList.length > 0) {
     var dataToSend = _this._batchData(datapointsList);


### PR DESCRIPTION
Calling splice() is more efficient than shift()ing from the start of the array up to batchSize(default of 300) times.
The amount of time taken by shift() is proportional to the length of the array. This would only matter for large arrays.