### PR TITLE
fix: Send remaining queue items if there are more than chunkSize

### DIFF
--- a/lib/client/ingest/signal_fx_client.js
+++ b/lib/client/ingest/signal_fx_client.js
@@ -289,7 +289,14 @@ SignalFxClient.prototype.post = function (data, postUrl, contentType) {
   };
 
   return tracing.withNonReportingScope(() => axios(postOptions).then(
-    (response) => response.data,
+    (response) => {
+      if (this.queue.length > 0) {
+        this.startAsyncSend().catch((error) => {
+          logger.error('Failed to send remaining datapoints: %s', error);
+        });
+      }
+      return response.data;
+    },
     (error) => {
       const { response } = error;
       if (response) {

--- a/test/ingest/signalfx.js
+++ b/test/ingest/signalfx.js
@@ -230,6 +230,34 @@ describe('SignalFx client library (Protobuf mode)', function () {
     setTimeout(function () {
       tracingStub.called.should.be.equal(true);
       requestStub.called.should.be.equal(true);
+      client.queue.length.should.be.equal(0);
+      done();
+    }, 2000);
+
+  });
+
+  it('Send many datapoints via queue', function (done) {
+    requestStub.resolves({ status: 200 });
+
+    var token = 'my token';
+    var client = new signalFx.Ingest(token);
+
+    var gauges = [];
+    // Test with more than the batchSize
+    for (let i = 0; i < 500; i++) {
+      gauges.push({
+        metric: `test.cpu${i}`,
+        value: 10,
+      });
+    }
+
+    client.send({gauges: gauges});
+
+    this.timeout(2020);
+    setTimeout(function () {
+      tracingStub.called.should.be.equal(true);
+      requestStub.called.should.be.equal(true);
+      client.queue.length.should.be.equal(0);
       done();
     }, 2000);
 


### PR DESCRIPTION
When the datapointsLength in a call to send() exceeded the chunkSize, the excess items would remain in the queue until there was another call with fewer than chunkSize datapoints.

If there were no future calls to send(), the items would remain in the queue.

For now, only do this when the previous data is successfully sent to signalfx

Fixes #105