### PR TITLE
Update type definition for Signalflow client

### DIFF
--- a/lib/signalfx.d.ts
+++ b/lib/signalfx.d.ts
@@ -14,6 +14,7 @@ export interface ExecuteOptions {
     usedByDetectorUI?: boolean;
     useCache?: boolean;
     compress?: boolean;
+    filter?: string;
 }
 
 type SignalFlow = (token: string, options: SignalFlowClientOptions) => SignalFlowClient;


### PR DESCRIPTION
Add `filter` param to the Signalflow client `ExecuteOptions` definition (allows filters to be passed in separately from the program text when executing Signalflow).